### PR TITLE
Support VM naming and custom metadata

### DIFF
--- a/action/cloud_properties.go
+++ b/action/cloud_properties.go
@@ -32,6 +32,7 @@ type StemcellCloudProperties struct {
 }
 
 type VMCloudProperties struct {
+	Name              string          `json:"name,omitempty"`
 	Zone              string          `json:"zone,omitempty"`
 	MachineType       string          `json:"machine_type,omitempty"`
 	CPU               int             `json:"cpu,omitempty"`

--- a/action/cloud_properties.go
+++ b/action/cloud_properties.go
@@ -43,6 +43,7 @@ type VMCloudProperties struct {
 	OnHostMaintenance string          `json:"on_host_maintenance,omitempty"`
 	Preemptible       bool            `json:"preemptible,omitempty"`
 	ServiceScopes     VMServiceScopes `json:"service_scopes,omitempty"`
+	Metadata          VMMetadata      `json:"metadata,omitempty"`
 }
 
 type VMServiceScopes []string

--- a/action/create_vm.go
+++ b/action/create_vm.go
@@ -88,7 +88,8 @@ func (cv CreateVM) Run(agentID string, stemcellCID StemcellCID, cloudProps VMClo
 	}
 
 	// Parse VM properties
-	vmProps := &instance.Properties{
+	vmConfig := &instance.VMConfig{
+		Name:              cloudProps.Name,
 		Zone:              zone,
 		Stemcell:          stemcellLink,
 		MachineType:       machineTypeLink,
@@ -101,7 +102,7 @@ func (cv CreateVM) Run(agentID string, stemcellCID StemcellCID, cloudProps VMClo
 	}
 
 	// Create VM
-	vm, err := cv.vmService.Create(vmProps, vmNetworks, cv.registryOptions.EndpointWithCredentials())
+	vm, err := cv.vmService.Create(vmConfig, vmNetworks, cv.registryOptions.EndpointWithCredentials())
 	if err != nil {
 		if _, ok := err.(api.CloudError); ok {
 			return "", err

--- a/action/create_vm.go
+++ b/action/create_vm.go
@@ -99,6 +99,7 @@ func (cv CreateVM) Run(agentID string, stemcellCID StemcellCID, cloudProps VMClo
 		OnHostMaintenance: cloudProps.OnHostMaintenance,
 		Preemptible:       cloudProps.Preemptible,
 		ServiceScopes:     instance.ServiceScopes(cloudProps.ServiceScopes),
+		Metadata:          instance.Metadata(cloudProps.Metadata),
 	}
 
 	// Create VM

--- a/action/create_vm_test.go
+++ b/action/create_vm_test.go
@@ -38,7 +38,7 @@ var _ = Describe("CreateVM", func() {
 		defaultRootDiskType      string
 		registryOptions          registry.ClientOptions
 		agentOptions             registry.AgentOptions
-		expectedVMProps          *instance.Properties
+		expectedVMProps          *instance.VMConfig
 		expectedInstanceNetworks instance.Networks
 		expectedAgentSettings    registry.AgentSettings
 
@@ -129,7 +129,7 @@ var _ = Describe("CreateVM", func() {
 				},
 			}
 
-			expectedVMProps = &instance.Properties{
+			expectedVMProps = &instance.VMConfig{
 				Zone:              "fake-default-zone",
 				Stemcell:          "fake-image-self-link",
 				MachineType:       "fake-machine-type-self-link",

--- a/google/instance_service/fakes/fake_instance_service.go
+++ b/google/instance_service/fakes/fake_instance_service.go
@@ -26,7 +26,7 @@ type FakeInstanceService struct {
 	CreateCalled           bool
 	CreateErr              error
 	CreateID               string
-	CreateVMProps          *instance.Properties
+	CreateVMProps          *instance.VMConfig
 	CreateNetworks         instance.Networks
 	CreateRegistryEndpoint string
 
@@ -86,7 +86,7 @@ func (i *FakeInstanceService) CleanUp(id string) {
 	return
 }
 
-func (i *FakeInstanceService) Create(vmProps *instance.Properties, networks instance.Networks, registryEndpoint string) (string, error) {
+func (i *FakeInstanceService) Create(vmProps *instance.VMConfig, networks instance.Networks, registryEndpoint string) (string, error) {
 	i.CreateCalled = true
 	i.CreateVMProps = vmProps
 	i.CreateNetworks = networks

--- a/google/instance_service/google_instance_service_create.go
+++ b/google/instance_service/google_instance_service_create.go
@@ -115,9 +115,9 @@ func (i GoogleInstanceService) createMatadataParams(config *VMConfig, regEndpoin
 	metadataItem := &compute.MetadataItems{Key: userDataKey, Value: &userDataValue}
 	metadataItems = append(metadataItems, metadataItem)
 
-	for k, _ := range config.Metadata {
-		val := config.Metadata[k].(string)
-		metadataItems = append(metadataItems, &compute.MetadataItems{Key: k, Value: &val})
+	for k := range config.Metadata {
+		v := config.Metadata[k].(string)
+		metadataItems = append(metadataItems, &compute.MetadataItems{Key: k, Value: &v})
 	}
 
 	metadata := &compute.Metadata{Items: metadataItems}

--- a/google/instance_service/google_instance_service_create.go
+++ b/google/instance_service/google_instance_service_create.go
@@ -115,8 +115,9 @@ func (i GoogleInstanceService) createMatadataParams(config *VMConfig, regEndpoin
 	metadataItem := &compute.MetadataItems{Key: userDataKey, Value: &userDataValue}
 	metadataItems = append(metadataItems, metadataItem)
 
-	for k, v := range config.Metadata {
-		metadataItems = append(metadataItems, &compute.MetadataItems{Key: k, Value: v.(*string)})
+	for k, _ := range config.Metadata {
+		val := config.Metadata[k].(string)
+		metadataItems = append(metadataItems, &compute.MetadataItems{Key: k, Value: &val})
 	}
 
 	metadata := &compute.Metadata{Items: metadataItems}

--- a/google/instance_service/instance_service.go
+++ b/google/instance_service/instance_service.go
@@ -10,7 +10,7 @@ type Service interface {
 	AttachDisk(id string, diskLink string) (string, string, error)
 	AttachedDisks(id string) (AttachedDisks, error)
 	CleanUp(id string)
-	Create(vmProps *Properties, networks Networks, registryEndpoint string) (string, error)
+	Create(vmConfig *VMConfig, networks Networks, registryEndpoint string) (string, error)
 	Delete(id string) error
 	DeleteAccessConfig(id string, zone string, networkInterface string, accessConfig string) error
 	DeleteNetworkConfiguration(id string) error
@@ -26,7 +26,11 @@ type AttachedDisks []string
 
 type Metadata map[string]interface{}
 
-type Properties struct {
+type VMConfig struct {
+	// Name is the optional name that will be assigned to the GCE VM on creation.
+	// Names must be unique within a GCP project.
+	// The nil value will means a UUID will be used for the VM name.
+	Name              string
 	Zone              string
 	Stemcell          string
 	MachineType       string

--- a/google/instance_service/instance_service.go
+++ b/google/instance_service/instance_service.go
@@ -33,6 +33,7 @@ type VMConfig struct {
 	Name              string
 	Zone              string
 	Stemcell          string
+	Metadata          Metadata
 	MachineType       string
 	RootDiskSizeGb    int
 	RootDiskType      string


### PR DESCRIPTION
These changes allow the user to set the name of a GCE instance with the `cloud_properties.name` key, and customize instance metadata with the `cloud_properties.metadata` map:

``` yaml
resource_pools:
  - name: vms
    network: private
    cloud_properties:
      name: bosh-director
      machine_type: n1-standard-4
      metadata:
        startup-script: |
          #!/bin/bash
          ifconfig eth0:0 10.1.1.1 netmask 255.255.255.0 up
```

Setting a custom instance name provides a workaround to the lack of static private IPs in GCE: a known instance name allows a custom route to point traffic to that instance by name.

Custom metadata allows, among other things, a `startup-script` to be provided. In the example above, that script is used to configure a secondary virtual network interface that will receive traffic from a private static IP provided by GCE routing.
